### PR TITLE
cap sensitive unix based fix

### DIFF
--- a/puzzlebobble.py
+++ b/puzzlebobble.py
@@ -104,7 +104,7 @@ class Arrow(pygame.sprite.Sprite):
         pygame.sprite.Sprite.__init__(self)
 
         self.angle = 90
-        arrowImage = pygame.image.load('arrow.png')
+        arrowImage = pygame.image.load('Arrow.png')
         arrowImage.convert_alpha()
         arrowRect = arrowImage.get_rect()
         self.image = arrowImage


### PR DESCRIPTION
Linux systems are cap sensitive 

```
metulburr@arch ~/Downloads/bubbleshooter-master $ python2 puzzlebobble.py 
Traceback (most recent call last):
  File "puzzlebobble.py", line 665, in <module>
    main()
  File "puzzlebobble.py", line 165, in main
    score, winorlose = runGame()
  File "puzzlebobble.py", line 182, in runGame
    arrow = Arrow()
  File "puzzlebobble.py", line 107, in __init__
    arrowImage = pygame.image.load('arrow.png')
pygame.error: Couldn't open arrow.png

```
